### PR TITLE
feat: added support for A1 + Sheet reference notation

### DIFF
--- a/__tests__/Range.test.ts
+++ b/__tests__/Range.test.ts
@@ -44,7 +44,7 @@ describe('Range', () => {
 
       expect(value).toEqual('Kwickiemart');
     });
-    it('should return value using A1 notation', () => {
+    it('should return value using a1 notation', () => {
       const value = sheet.getRange('C6').getValue();
 
       expect(value).toEqual('Wholepaycheck');
@@ -59,7 +59,7 @@ describe('Range', () => {
 
       expect(value).toEqual('Gasmart');
     });
-    it('should return value using A1 notation plus sheet reference', () => {
+    it('should return value using a1 notation plus sheet reference', () => {
       const value = sheet.getRange('TestSheet!C5').getValue();
 
       expect(value).toEqual('Gasmart');

--- a/__tests__/Range.test.ts
+++ b/__tests__/Range.test.ts
@@ -44,7 +44,7 @@ describe('Range', () => {
 
       expect(value).toEqual('Kwickiemart');
     });
-    it('should return value using a1 notation', () => {
+    it('should return value using A1 notation', () => {
       const value = sheet.getRange('C6').getValue();
 
       expect(value).toEqual('Wholepaycheck');
@@ -56,6 +56,11 @@ describe('Range', () => {
     });
     it('should only return top left value from range using a1 notation', () => {
       const value = sheet.getRange('C5:D6').getValue();
+
+      expect(value).toEqual('Gasmart');
+    });
+    it('should return value using A1 notation plus sheet reference', () => {
+      const value = sheet.getRange('TestSheet!C5').getValue();
 
       expect(value).toEqual('Gasmart');
     });

--- a/src/SpreadsheetApp/Range.ts
+++ b/src/SpreadsheetApp/Range.ts
@@ -202,8 +202,10 @@ function getValuesFromA1Notation(values: any[][], textRange: string): any[][] {
 
 function cellToRoWCol(cell: string): [number, number] {
   // returns row & col from A1 notation
-  let row = Number(cell.replace(/[^0-9]+/g, ''));
-  const letter = cell.replace(/[^a-zA-Z]+/g, '').toUpperCase();
+  // Ignore sheet name if present
+  const cellOnly = cell.split('!').slice(-1)[0];
+  let row = Number(cellOnly.replace(/[^0-9]+/g, ''));
+  const letter = cellOnly.replace(/[^a-zA-Z]+/g, '').toUpperCase();
   let column = letterToColumn(letter);
 
   row = row - 1;


### PR DESCRIPTION
Thank you for this work! I know it doesn't have much traction, but I still use this for pet projects.

# Changes added

- Added support for A1 notation plus sheet name reference (e.g. `Sheet1!A20`)